### PR TITLE
Fixed File Delete API & Added New API to retrieve all file UUIDs

### DIFF
--- a/controllers/meta/Metamodel_files.controller.ts
+++ b/controllers/meta/Metamodel_files.controller.ts
@@ -256,6 +256,24 @@ class Metamodel_filesController {
             (await client).release();
         }
     };
+
+    public get_all_uuids: RequestHandler = async (req, res, next) => {
+        const client = await database_connection.getPool().connect();
+        try {
+            await client.query("BEGIN");
+            const queryResult = await client.query("SELECT uuid_metaobject FROM file;");
+            await client.query("COMMIT");
+
+            res.status(200).json({
+                uuids: queryResult.rows.map(row => row.uuid_metaobject),
+            });
+        } catch (err) {
+            await client.query("ROLLBACK");
+            next(err);
+        } finally {
+            client.release();
+        }
+    };
 }
 
 export default new Metamodel_filesController();

--- a/routes/metamodel/Metamodel_files.routes.ts
+++ b/routes/metamodel/Metamodel_files.routes.ts
@@ -52,6 +52,8 @@ fileRouter.get(
   }
 );
 
+fileRouter.get("/alluuids", Metamodel_file_controller.get_all_uuids);
+
 fileRouter.get(
   /*
   #swagger.tags = ['Files']


### PR DESCRIPTION
# Made changes to deleteByUuid() in data/meta/Metamodel_metaobjects.connection.ts
- Fixed improper database function call to delete_and_return_violation()
- Added code to check if the meta object exists in the database in order to delete it
- Fixed improper return statement; UUIDs to return

Edit:
# Made changes to files routes and controllers
-Added new API to retrieve all the file UUIDs, which is later useful to download individual files.